### PR TITLE
Create deploy to staging.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up SSH
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.STAGING_SSH_KEY }}
+
+    - name: Pull latest changes on staging server
+      run: |
+        ssh -o StrictHostKeyChecking=no user@staging-server 'cd /home/nmcdev/nmc-website && git pull origin main && docker-compose -f docker-compose.prod.yml up -d --build'


### PR DESCRIPTION
Created a `.github/workflows/deploy.yml` file that creates a GitHub Action

This action does the following.

Upon push to the main branch:
The GitHub Action provisions an ubuntu-latest and runs a job on it that:

- Checks out the main branch.
- SSHes into our staging server with our SSL key.
- Once logged in...
    1. changes directory to /home/nmcdev/nmc-website
    2. pulls the latest nmc-website **main** branch to the staging server
    3. runs `docker-compose.prod.yml up -d --build` to build new docker images and start them.

This is currently untested, so we'll see what happens when I try to run it!